### PR TITLE
fix "double-v" displayed in version string within Alfred

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := $(shell git describe --tags --abbrev=0)
+VERSION := $(shell git describe --tags --abbrev=0 | tr -cd '[0-9.]')
 REVISION := $(shell git rev-parse --short HEAD)
 SRC_DIR := ./
 BIN_NAME := tldr

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := $(shell git describe --tags --abbrev=0 | tr -cd '[0-9.]')
+VERSION := $(shell git describe --tags --abbrev=0)
 REVISION := $(shell git rev-parse --short HEAD)
 SRC_DIR := ./
 BIN_NAME := tldr
@@ -47,7 +47,8 @@ test:
 
 ## embed current version into workflow config
 embed-version:
-	@(plutil -replace version -string $(VERSION) $(ASSETS_DIR)/info.plist)
+	$(eval SEMVER := $(shell echo $(VERSION) | tr -cd '[0-9.]'))
+	@(plutil -replace version -string $(SEMVER) $(ASSETS_DIR)/info.plist)
 
 ## Install Binary and Assets to Workflow Directory
 install: build embed-version


### PR DESCRIPTION
small change to Makefile to strip non-numeric part of version string

![CleanShot 2021-08-21 at 11 01 40](https://user-images.githubusercontent.com/1992842/130325964-7132d4cb-591e-4300-8c23-cc48c15fdc7b.png)

to

![CleanShot 2021-08-21 at 11 01 56](https://user-images.githubusercontent.com/1992842/130325972-8d573620-d6ea-4488-beb0-e1e00906b5b7.png)
